### PR TITLE
assetDir, gulp-rev

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
 	"main": "index.js",
 	"dependencies": {
 		"gulp-util": "latest",
-		"through2": "latest"
+		"through2": "latest",
+		"gulp-rev": "latest"
 	},
 	"devDependencies": {
 		"event-stream": "latest",


### PR DESCRIPTION
Add assetDir option.
Add gulp-rev integration (to emulate the functionality of grunt-usemin:prepare.

I am submitting this as a working example. These are almost the last features needed to allow gulp-usemin to replace grunt-usemin for the yeoman angular-fullstack generator. 

The only other feature I can think of is the alternate path format of 
`({.tmp, app}).` I believe if the file is found in the first directory, the second is ignored. This issue isnt something I really need but it might be nice to integrate. 

Thank you for your work on this! 
