### PR TITLE
[Bug Fix] Allow gulp-usemin to work with minified source HTML.

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,10 +8,10 @@ var gutil = require('gulp-util');
 module.exports = function (options) {
 	options = options || {}; // cssmin, htmlmin, jsmin
 
-	var startReg = /<!--\s*build:(css|js)(?:\(([^\)]+)\))?\s+(\/?([^\s]+))\s*-->/gim;
+	var startReg = /<!--\s*build:(css|js)(?:\(([^\)]+?)\))?\s+(\/?([^\s]+?))\s*-->/gim;
 	var endReg = /<!--\s*endbuild\s*-->/gim;
-	var jsReg = /<\s*script\s+.*src\s*=\s*"([^"]+)".*><\s*\/\s*script\s*>/gi;
-	var cssReg = /<\s*link\s+.*href\s*=\s*"([^"]+)".*>/gi;
+	var jsReg = /<\s*script\s+.*?src\s*=\s*"([^"]+?)".*?><\s*\/\s*script\s*>/gi;
+	var cssReg = /<\s*link\s+.*?href\s*=\s*"([^"]+)".*?>/gi;
 	var basePath, mainPath, mainName, alternatePath;
 	var filesCount = 0;
 

--- a/test/expected/min-html-simple-css.html
+++ b/test/expected/min-html-simple-css.html
@@ -1,0 +1,1 @@
+<link rel="stylesheet" href="/style.css"/>

--- a/test/expected/min-html-simple-js.html
+++ b/test/expected/min-html-simple-js.html
@@ -1,0 +1,1 @@
+<script src="app.js"></script>

--- a/test/fixtures/min-html-simple-css.html
+++ b/test/fixtures/min-html-simple-css.html
@@ -1,0 +1,1 @@
+<!-- build:css /style.css --><link rel="stylesheet" href="css/clear.css"/><link rel="stylesheet" href="css/main.css"/><!-- endbuild -->

--- a/test/fixtures/min-html-simple-js.html
+++ b/test/fixtures/min-html-simple-js.html
@@ -1,0 +1,1 @@
+<!-- build:js app.js --><script src="js/lib.js"></script><script src="js/main.js"></script><!-- endbuild -->

--- a/test/main.js
+++ b/test/main.js
@@ -138,12 +138,20 @@ describe('gulp-usemin', function() {
 				compare('simple-js.html', 'simple-js.html', done);
 			});
 
+			it('simple (js block) (html minified)', function(done) {
+				compare('min-html-simple-js.html', 'min-html-simple-js.html', done);
+			});
+
 			it('simple with path (js block)', function(done) {
 				compare('simple-js-path.html', 'simple-js-path.html', done);
 			});
 
 			it('simple (css block)', function(done) {
 				compare('simple-css.html', 'simple-css.html', done);
+			});
+
+			it('simple (css block) (html minified)', function(done) {
+				compare('min-html-simple-css.html', 'min-html-simple-css.html', done);
 			});
 
 			it('simple with path (css block)', function(done) {
@@ -248,6 +256,25 @@ describe('gulp-usemin', function() {
 
 				compare(
 					'simple-css.html',
+					function(newFile) {
+						if (newFile.path === expectedName) {
+							exist = true;
+							assert.equal(String(getExpected(expectedName).contents), String(newFile.contents));
+						}
+					},
+					function() {
+						assert.ok(exist);
+						done();
+					}
+				);
+			});
+
+			it('simple (css block) (minified html)', function(done) {
+				var expectedName = 'style.css';
+				var exist = false;
+
+				compare(
+					'min-html-simple-css.html',
 					function(newFile) {
 						if (newFile.path === expectedName) {
 							exist = true;
@@ -389,6 +416,25 @@ describe('gulp-usemin', function() {
 
 				compare(
 					'simple-js.html',
+					function(newFile) {
+						if (newFile.path === expectedName) {
+							exist = true;
+							assert.equal(String(getExpected(expectedName).contents), String(newFile.contents));
+						}
+					},
+					function() {
+						assert.ok(exist);
+						done();
+					}
+				);
+			});
+
+			it('simple (js block) (minified html)', function(done) {
+				var expectedName = 'app.js';
+				var exist = false;
+
+				compare(
+					'min-html-simple-js.html',
 					function(newFile) {
 						if (newFile.path === expectedName) {
 							exist = true;


### PR DESCRIPTION
- The matching from some of the regular expression were too greedy and would not work if the source HTML with the build comment was minified.
- This PR turns some of the greedy matching to lazy matching so that this plugin will work with minified HTML as the source.
