### PR TITLE
When using an alternate path, resolve the path before using it.

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = function (options) {
 		content
 			.replace(/<!--(?:(?:.|\r|\n)*?)-->/gim, '')
 			.replace(reg, function (a, b) {
-				paths.push(path.join(alternatePath || mainPath, b));
+				paths.push(path.resolve(path.join(alternatePath || mainPath, b)));
 			});
 
 		for (var i = 0, l = paths.length; i < l; ++i)


### PR DESCRIPTION
There is an edge case where if your src file is outside of your `gulpfile.js` directory, your alternate path may not work under certain circumstances (such as if the alt path is up any directories).

To create a test for this, I'd have to have files outside of the repo, or change where the `gulpfile.js` is, so it's not a trivial thing.

This change does not break any current changes and fixes the described edge case issue I was having.
