### PR TITLE
fix assetsDir option and add tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = function(options) {
 				var filePath = path.resolve(path.join(alternatePath || mainPath, b));
 
 				if (options.assetsDir)
-					filePath = path.relative(basePath, path.join(options.assetsDir, filePath));
+					filePath = path.resolve(path.join(options.assetsDir, path.relative(basePath, filePath)));
 
 				paths.push(filePath);
 			});

--- a/test/main.js
+++ b/test/main.js
@@ -534,5 +534,37 @@ describe('gulp-usemin', function() {
 			stream.write(getFixture('many-blocks.html'));
 			stream.end();
 		});
+
+		describe('assetsDir option:', function() {
+			function compare(assetsDir, done) {
+				var stream = usemin({assetsDir: assetsDir});
+				var expectedName = 'style.css';
+				var exist = false;
+				var callback = function(newFile) {
+					if (newFile.path === expectedName) {
+						exist = true;
+						assert.equal(String(getExpected(expectedName).contents), String(newFile.contents));
+					}
+				};
+				var end = function() {
+					assert.ok(exist);
+					done();
+				};
+
+				stream.on('data', callback);
+				stream.on('end', end);
+
+				stream.write(getFixture('simple-css.html'));
+				stream.end();
+			}
+
+			it('absolute path', function(done) {
+				compare(path.join(process.cwd(), 'test', 'fixtures'), done);
+			});
+
+			it('relative path', function(done) {
+				compare(path.join('test', 'fixtures'), done);
+			});
+		});
 	});
 });


### PR DESCRIPTION
assetsDir was being prepended to an absolute path and was not tested.
This adds tests and appends the relative path of the asset to assetsDir.
