### PR TITLE
added option to append query-like suffix

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,12 +109,23 @@ module.exports = function(options) {
 
 				if (getBlockType(section[5]) == 'js')
 					process(section[4], getFiles(section[5], jsReg), section[1], function(name, file) {
-						push(file);
-						if (path.extname(file.path) == '.js')
-							html.push('<script src="' + name.replace(path.basename(name), path.basename(file.path)) + '"></script>');
+                                        var prefile = file;
+                                        var fnameparts = file.path.split('?');
+                                        prefile.path = fnameparts[0];
+                                        var postfix = (fnameparts.length > 1) ? '?' + fnameparts[1] : '';
+
+                                        push(prefile);
+                                        if(path.extname(prefile.path) == '.js'){
+                                          html.push('<script src="' + name.replace(path.basename(name), path.basename(prefile.path)) + postfix + '"></script>');
+                                        }
 					}.bind(this, section[3]));
 				else
 					process(section[4], getFiles(section[5], cssReg), section[1], function(name, file) {
+                                           var prefile = file;
+                                           var fnameparts = file.path.split('?');
+                                           prefile.path = fnameparts[0];
+                                           var postfix = (fnameparts.length > 1) ? '?' + fnameparts[1] : '';
+
 						push(file);
 						html.push('<link rel="stylesheet" href="' + name.replace(path.basename(name), path.basename(file.path)) + '"/>');
 					}.bind(this, section[3]));


### PR DESCRIPTION
I am using this to append a file versioning to files for cache-busting
It can be used as static or dynamic in conjunction with gulp-bump/gulp-template

For example

```
<!-- build:js js/lib.js?v=<%= libversion%> -->
..some lib files...
<!-- endbuild -->
<!-- build:js js/app.js?v=<%= appversion%>-->
..some app files...
<!-- endbuild -->
```

will be translated to 

```
    <script src="js/lib.js?v=0.10.6"></script>
    <script src="js/app.js?v=0.7.3"></script>
```

```
var conf = {app: 'app/', dist: 'dist/'};
var pkg = require('./package.json');
gulp.task('usemin-test', function() {
  return gulp.src(conf.app + 'index.html')
  .pipe($('template')(pkg))
  .pipe($('usemin')())
  .pipe(gulp.dest(conf.dist));
});
```
