### PR TITLE
Support for conditional comments inside build blocks

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,8 @@ module.exports = function(options) {
 	var endReg = /<!--\s*endbuild\s*-->/gim;
 	var jsReg = /<\s*script\s+.*?src\s*=\s*"([^"]+?)".*?><\s*\/\s*script\s*>/gi;
 	var cssReg = /<\s*link\s+.*?href\s*=\s*"([^"]+)".*?>/gi;
+	var startCondReg = /<!--\[[^\]]+\]>/im;
+	var endCondReg = /<!\[endif\]-->/im;
 	var basePath, mainPath, mainName, alternatePath;
 
 	function createFile(name, content) {
@@ -110,6 +112,11 @@ module.exports = function(options) {
 
 				html.push(section[0]);
 
+				var startCondLine = section[5].match(startCondReg);
+				var endCondLine = section[5].match(endCondReg);
+				if (startCondLine && endCondLine)
+					html.push(startCondLine[0]);
+
 				if (getBlockType(section[5]) == 'js')
 					process(section[4], getFiles(section[5], jsReg), section[1], function(name, file) {
 						push(file);
@@ -121,6 +128,9 @@ module.exports = function(options) {
 						push(file);
 						html.push('<link rel="stylesheet" href="' + name.replace(path.basename(name), path.basename(file.path)) + '"/>');
 					}.bind(this, section[3]));
+
+				if (startCondLine && endCondLine)
+					html.push(endCondLine[0]);
 			}
 			else
 				html.push(sections[i]);

--- a/test/expected/conditional-complex.html
+++ b/test/expected/conditional-complex.html
@@ -1,0 +1,3 @@
+<!--[if IE 8]><link rel="stylesheet" href="style.css"/><![endif]-->
+
+<!--[if lt IE 9]><script src="app.js"></script><![endif]-->

--- a/test/expected/conditional-css.html
+++ b/test/expected/conditional-css.html
@@ -1,0 +1,1 @@
+<!--[if lt IE 9]><link rel="stylesheet" href="/style.css"/><![endif]-->

--- a/test/expected/conditional-js.html
+++ b/test/expected/conditional-js.html
@@ -1,0 +1,1 @@
+<!--[if lt IE 9]><script src="app.js"></script><![endif]-->

--- a/test/fixtures/conditional-complex.html
+++ b/test/fixtures/conditional-complex.html
@@ -1,0 +1,13 @@
+<!-- build:css style.css -->
+<!--[if IE 8]>
+<link rel="stylesheet" href="css/clear.css"/>
+<link rel="stylesheet" href="css/main.css"/>
+<![endif]-->
+<!-- endbuild -->
+
+<!-- build:js app.js -->
+<!--[if lt IE 9]>
+<script src="js/lib.js"></script>
+<script src="js/main.js"></script>
+<![endif]-->
+<!-- endbuild -->

--- a/test/fixtures/conditional-css.html
+++ b/test/fixtures/conditional-css.html
@@ -1,0 +1,6 @@
+<!-- build:css /style.css -->
+<!--[if lt IE 9]>
+<link rel="stylesheet" href="css/clear.css"/>
+<link rel="stylesheet" href="css/main.css"/>
+<![endif]-->
+<!-- endbuild -->

--- a/test/fixtures/conditional-js.html
+++ b/test/fixtures/conditional-js.html
@@ -1,0 +1,6 @@
+<!-- build:js app.js -->
+<!--[if lt IE 9]>
+<script src="js/lib.js"></script>
+<script src="js/main.js"></script>
+<![endif]-->
+<!-- endbuild -->

--- a/test/main.js
+++ b/test/main.js
@@ -570,5 +570,34 @@ describe('gulp-usemin', function() {
 				compare(path.join('test', 'fixtures'), done);
 			});
 		});
+
+		describe('conditional comments:', function() {
+			function compare(name, expectedName, done) {
+				var stream = usemin();
+
+				stream.on('data', function(newFile) {
+					if (path.basename(newFile.path) === name)
+						assert.equal(String(getExpected(expectedName).contents), String(newFile.contents));
+				});
+				stream.on('end', function() {
+					done();
+				});
+
+				stream.write(getFixture(name));
+				stream.end();
+			}
+
+			it('conditional (js block)', function(done) {
+				compare('conditional-js.html', 'conditional-js.html', done);
+			});
+
+			it('conditional (css block)', function(done) {
+				compare('conditional-css.html', 'conditional-css.html', done);
+			});
+
+			it('conditional (css + js)', function(done) {
+				compare('conditional-complex.html', 'conditional-complex.html', done);
+			});
+		});
 	});
 });


### PR DESCRIPTION
Making conditional comments (useful for loading css & js targeted at older IE for example) work with usemin build blocks was a pain: if the comments are placed outside the blocks, the build is correct but in development the code is fetched and executed in browser not supporting them; if the comments are inside, they are stripped away when processed.
This commit checks the presence of a conditional comment in each build block with a regExp taken from grunt-usemin code and outputs it around the generated tags.
Some simple tests have been added as well.
