### PR TITLE
Fixed bug with conditional comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,6 @@ module.exports = function(options) {
 		var files = [];
 
 		content
-			.replace(/<!--(?:(?:.|\r|\n)*?)-->/gim, '')
 			.replace(reg, function (a, b) {
 				var filePath = path.resolve(path.join(alternatePath || mainPath, b));
 


### PR DESCRIPTION
getFiles function strips away all html comments before parsing the files. This does not have any specific utility and it has the unpleasant effect of removing all files wrapped inside a conditional comment, thus resulting in an empty file. Removing this behaviour.
