### PR TITLE
Support multi-file globs

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,14 +46,16 @@ module.exports = function(options) {
 			});
 
 		for (var i = 0, l = paths.length; i < l; ++i) {
-			var filepath = glob.sync(paths[i])[0];
-			if(filepath === undefined) {
+			var filepaths = glob.sync(paths[i]);
+			if(filepaths[0] === undefined) {
 				throw new gutil.PluginError('gulp-usemin', 'Path ' + paths[i] + ' not found!');
 			}
-			files.push(new gutil.File({
-				path: filepath,
-				contents: fs.readFileSync(filepath)
-			}));
+			filepaths.forEach(function (filepath) {
+				files.push(new gutil.File({
+					path: filepath,
+					contents: fs.readFileSync(filepath)
+				}));
+			});
 		}
 
 		return files;

--- a/test/fixtures/glob-css.html
+++ b/test/fixtures/glob-css.html
@@ -1,0 +1,3 @@
+<!-- build:css /style.css -->
+<link rel="stylesheet" href="css/*.css"/>
+<!-- endbuild -->

--- a/test/fixtures/glob-js.html
+++ b/test/fixtures/glob-js.html
@@ -1,0 +1,3 @@
+<!-- build:js app.js -->
+<script src="js/*.js"></script>
+<!-- endbuild -->

--- a/test/main.js
+++ b/test/main.js
@@ -599,5 +599,55 @@ describe('gulp-usemin', function() {
 				compare('conditional-complex.html', 'conditional-complex.html', done);
 			});
 		});
+
+		describe('globbed files:', function() {
+			function compare(name, callback, end) {
+				var stream = usemin();
+
+				stream.on('data', callback);
+				stream.on('end', end);
+
+				stream.write(getFixture(name));
+				stream.end();
+			}
+
+			it('glob (js block)', function(done) {
+				var expectedName = 'app.js';
+				var exist = false;
+
+				compare(
+					'glob-js.html',
+					function(newFile) {
+						if (newFile.path === expectedName) {
+							exist = true;
+							assert.equal(String(newFile.contents), String(getExpected(expectedName).contents));
+						}
+					},
+					function() {
+						assert.ok(exist);
+						done();
+					}
+				);
+			});
+
+			it('glob (css block)', function(done) {
+				var expectedName = 'style.css';
+				var exist = false;
+
+				compare(
+					'glob-css.html',
+					function(newFile) {
+						if (newFile.path === expectedName) {
+							exist = true;
+							assert.equal(String(newFile.contents), String(getExpected(expectedName).contents));
+						}
+					},
+					function() {
+						assert.ok(exist);
+						done();
+					}
+				);
+			});
+		});
 	});
 });


### PR DESCRIPTION
Since glob was already a dependency, it was trivial to enable multi-file globs in processed `<script>` and `<link>` tags. The changes are tiny and fully covered by accompanying tests.
