### PR TITLE
Provide plugin to resolve globs for development

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,59 +6,60 @@ var through = require('through2');
 var gutil = require('gulp-util');
 var glob = require('glob');
 
-module.exports = function(options) {
+var startReg = /<!--\s*build:(\w+)(?:\(([^\)]+?)\))?\s+(\/?([^\s]+?))\s*-->/gim;
+var endReg = /<!--\s*endbuild\s*-->/gim;
+var jsReg = /<\s*script\s+.*?src\s*=\s*"([^"]+?)".*?><\s*\/\s*script\s*>/gi;
+var cssReg = /<\s*link\s+.*?href\s*=\s*"([^"]+)".*?>/gi;
+var startCondReg = /<!--\[[^\]]+\]>/gim;
+var endCondReg = /<!\[endif\]-->/gim;
+
+function getBlockType(content) {
+	return jsReg.test(content) ? 'js' : 'css';
+}
+
+function getFiles(content, reg, options, basePath, mainPath, alternatePath) {
+	var paths = [];
+	var files = [];
+
+	content
+		.replace(startCondReg, '')
+		.replace(endCondReg, '')
+		.replace(/<!--(?:(?:.|\r|\n)*?)-->/gim, '')
+		.replace(reg, function (a, b) {
+			var filePath = path.resolve(path.join(alternatePath || mainPath, b));
+
+			if (options.assetsDir)
+				filePath = path.resolve(path.join(options.assetsDir, path.relative(basePath, filePath)));
+
+			paths.push(filePath);
+		});
+
+	for (var i = 0, l = paths.length; i < l; ++i) {
+		var filepaths = glob.sync(paths[i]);
+		if(filepaths[0] === undefined) {
+			throw new gutil.PluginError('gulp-usemin', 'Path ' + paths[i] + ' not found!');
+		}
+		filepaths.forEach(function (filepath) {
+			files.push(new gutil.File({
+				path: filepath,
+				contents: fs.readFileSync(filepath)
+			}));
+		});
+	}
+
+	return files;
+}
+
+var usemin = function(options) {
 	options = options || {};
 
-	var startReg = /<!--\s*build:(\w+)(?:\(([^\)]+?)\))?\s+(\/?([^\s]+?))\s*-->/gim;
-	var endReg = /<!--\s*endbuild\s*-->/gim;
-	var jsReg = /<\s*script\s+.*?src\s*=\s*"([^"]+?)".*?><\s*\/\s*script\s*>/gi;
-	var cssReg = /<\s*link\s+.*?href\s*=\s*"([^"]+)".*?>/gi;
-	var startCondReg = /<!--\[[^\]]+\]>/gim;
-	var endCondReg = /<!\[endif\]-->/gim;
 	var basePath, mainPath, mainName, alternatePath;
 
 	function createFile(name, content) {
 		return new gutil.File({
 			path: path.join(path.relative(basePath, mainPath), name),
 			contents: new Buffer(content)
-		})
-	}
-
-	function getBlockType(content) {
-		return jsReg.test(content) ? 'js' : 'css';
-	}
-
-	function getFiles(content, reg) {
-		var paths = [];
-		var files = [];
-
-		content
-			.replace(startCondReg, '')
-			.replace(endCondReg, '')
-			.replace(/<!--(?:(?:.|\r|\n)*?)-->/gim, '')
-			.replace(reg, function (a, b) {
-				var filePath = path.resolve(path.join(alternatePath || mainPath, b));
-
-				if (options.assetsDir)
-					filePath = path.resolve(path.join(options.assetsDir, path.relative(basePath, filePath)));
-
-				paths.push(filePath);
-			});
-
-		for (var i = 0, l = paths.length; i < l; ++i) {
-			var filepaths = glob.sync(paths[i]);
-			if(filepaths[0] === undefined) {
-				throw new gutil.PluginError('gulp-usemin', 'Path ' + paths[i] + ' not found!');
-			}
-			filepaths.forEach(function (filepath) {
-				files.push(new gutil.File({
-					path: filepath,
-					contents: fs.readFileSync(filepath)
-				}));
-			});
-		}
-
-		return files;
+		});
 	}
 
 	function concat(files, name) {
@@ -122,13 +123,13 @@ module.exports = function(options) {
 					html.push(startCondLine[0]);
 
 				if (getBlockType(section[5]) == 'js')
-					process(section[4], getFiles(section[5], jsReg), section[1], function(name, file) {
+					process(section[4], getFiles(section[5], jsReg, options, basePath, mainPath, alternatePath), section[1], function(name, file) {
 						push(file);
 						if (path.extname(file.path) == '.js')
 							html.push('<script src="' + name.replace(path.basename(name), path.basename(file.path)) + '"></script>');
 					}.bind(this, section[3]));
 				else
-					process(section[4], getFiles(section[5], cssReg), section[1], function(name, file) {
+					process(section[4], getFiles(section[5], cssReg, options, basePath, mainPath, alternatePath), section[1], function(name, file) {
 						push(file);
 						html.push('<link rel="stylesheet" href="' + name.replace(path.basename(name), path.basename(file.path)) + '"/>');
 					}.bind(this, section[3]));
@@ -163,3 +164,53 @@ module.exports = function(options) {
 		}
 	});
 };
+
+usemin.resolveGlobs = function () {
+	var basePath, mainPath, alternatePath;
+
+	function resolveGlobs(content) {
+		var html = [];
+		var sections = content.split(endReg);
+
+		for (var i = 0, l = sections.length; i < l; ++i)
+			if (sections[i].match(startReg)) {
+				var section = sections[i].split(startReg);
+				alternatePath = section[2];
+
+				html.push(section[0]);
+
+				var startCondLine = section[5].match(startCondReg);
+				var endCondLine = section[5].match(endCondReg);
+				if (startCondLine && endCondLine)
+					html.push(startCondLine[0]);
+
+				if (getBlockType(section[5]) == 'js')
+					getFiles(section[5], jsReg, {}, basePath, mainPath, alternatePath).forEach(function (file) {
+						if (path.extname(file.path) == '.js')
+							html.push('<script src="' + path.relative(basePath, file.path) + '"></script>');
+					});
+				else
+					getFiles(section[5], cssReg, {}, basePath, mainPath, alternatePath).forEach(function (file) {
+						html.push('<link rel="stylesheet" href="' + path.relative(basePath, file.path) + '"/>');
+					});
+				if (startCondLine && endCondLine)
+					html.push(endCondLine[0]);
+			}
+			else
+				html.push(sections[i]);
+
+		return html.join('');
+	}
+
+	return through.obj(function (file, enc, callback) {
+		basePath = file.base;
+		mainPath = path.dirname(file.path);
+
+		file.contents = new Buffer(resolveGlobs((String(file.contents))), 'utf-8');
+		this.push(file);
+
+		callback();
+	});
+};
+
+module.exports = usemin;

--- a/test/expected/resolved-glob-css.html
+++ b/test/expected/resolved-glob-css.html
@@ -1,0 +1,1 @@
+<link rel="stylesheet" href="css/clear.css"/><link rel="stylesheet" href="css/main.css"/>

--- a/test/expected/resolved-glob-js-plus-literal.html
+++ b/test/expected/resolved-glob-js-plus-literal.html
@@ -1,0 +1,1 @@
+<script src="alternative/js/util.js"></script><script src="js/lib.js"></script><script src="js/main.js"></script>

--- a/test/expected/resolved-glob-js.html
+++ b/test/expected/resolved-glob-js.html
@@ -1,0 +1,1 @@
+<script src="js/lib.js"></script><script src="js/main.js"></script>

--- a/test/fixtures/glob-js-plus-literal.html
+++ b/test/fixtures/glob-js-plus-literal.html
@@ -1,0 +1,4 @@
+<!-- build:js app.js -->
+<script src="alternative/js/util.js"></script>
+<script src="js/*.js"></script>
+<!-- endbuild -->

--- a/test/main.js
+++ b/test/main.js
@@ -650,4 +650,37 @@ describe('gulp-usemin', function() {
 			});
 		});
 	});
+
+	describe('glob resolver', function () {
+		function compare(name, expectedName, done) {
+			var exist = false;
+			var stream = usemin.resolveGlobs();
+			stream.on('data', function(newFile) {
+				if (path.basename(newFile.path) === name) {
+					assert.equal(String(newFile.contents), String(getExpected(expectedName).contents));
+					exist = true;
+				}
+			});
+
+			stream.on('end', function() {
+				assert.ok(exist, 'expected file ' + name);
+				done();
+			});
+			stream.write(getFixture(name));
+
+			stream.end();
+		}
+
+		it('should replace css globs with resolved file paths', function (done) {
+			compare('glob-css.html', 'resolved-glob-css.html', done);
+		});
+
+		it('should replace js globs with resolved file paths', function(done) {
+			compare('glob-js.html', 'resolved-glob-js.html', done);
+		});
+
+		it('should retain non-glob files paths', function(done) {
+			compare('glob-js-plus-literal.html', 'resolved-glob-js-plus-literal.html', done);
+		});
+	});
 });


### PR DESCRIPTION
This is an extension to my previous pull request to allow resolution of file globs to a list of fully-expanded filenames by exposing a new `usemin.resolveGlobs` method. It's intended to help out with development when globs are used, since they can't be interpreted directly by a browser.

Since I didn't know whether you'd be interested in incorporating this into your plugin, this change was made with as little impact to the rest of the plugin as possible. That means there's some code duplication in there, which I would be happy to refactor if you would like to merge this feature.

If you don't want this feature in the plugin, I could publish this functionality as a separate plugin (`gulp-usemin-resolve-globs` maybe?) but it would mean I'd have to copy the section-matching and file-resolution logic out of your codebase. I figure it would be more convenient to keep them together.

Let me know if you want to see real-life usage examples.
