### PR TITLE
Allow new js and css to go into a different directory than new html

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ Type: `Array`
 
 If exist used for modify files. If does not contain string 'concat', then it added as first member of pipeline
 
+#### ouputRelativePath
+Type: `String`
+Relative location to html file for new concatenated js and css.
 
 ## Use case
 

--- a/index.js
+++ b/index.js
@@ -18,8 +18,14 @@ module.exports = function(options) {
 	var basePath, mainPath, mainName, alternatePath;
 
 	function createFile(name, content) {
+		var filePath = path.join(path.relative(basePath, mainPath), name)
+		var isStatic = name.split('.').pop() === 'js' || name.split('.').pop() === 'css'
+
+		if (options.ouputRelativePath && isStatic)
+				filePath = options.ouputRelativePath + name;
+
 		return new gutil.File({
-			path: path.join(path.relative(basePath, mainPath), name),
+			path: filePath,
 			contents: new Buffer(content)
 		})
 	}


### PR DESCRIPTION
Hey,

Not sure if this was the intent of the assetDir option, but it is operating as the alternate search path. Regardless I added an option to place the new js/css in a relative path to the new html (or the like..ejs,ect etc), file.

-Ben
