### PR TITLE
refactor(async): add support for async transforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,20 +4,22 @@
 	"description": "Replaces references to non-optimized scripts or stylesheets into a set of HTML files (or any templates/views).",
 	"main": "index.js",
 	"dependencies": {
-		"gulp-util": "~2.2.14",
-		"through2": "~0.5.1",
-		"glob": "~4.0.4"
+		"glob": "^4.0.5",
+		"gulp-util": "^2.2.20",
+		"merge-stream": "^0.1.5",
+		"multipipe": "^0.1.1",
+		"through2": "^0.6.1"
 	},
 	"devDependencies": {
-		"event-stream": "~3.1.0",
-		"gulp": "~3.8.6",
-		"gulp-jshint": "~1.7.0",
-		"gulp-mocha": "~0.5.1",
-		"gulp-util": "~2.2.14",
+		"event-stream": "~3.1.7",
+		"gulp": "~3.8.7",
+		"gulp-jshint": "~1.8.4",
+		"gulp-mocha": "~1.0.0",
+		"gulp-util": "~3.0.0",
 		"gulp-uglify": "~0.3.1",
-		"gulp-minify-html": "~0.1.1",
-		"gulp-minify-css": "~0.3.0",
-		"gulp-rev": "~0.4.2"
+		"gulp-minify-html": "~0.1.4",
+		"gulp-minify-css": "~0.3.7",
+		"gulp-rev": "~1.0.0"
 	},
 	"scripts": {
 		"test": "mocha"

--- a/src/concat.js
+++ b/src/concat.js
@@ -1,0 +1,43 @@
+'use strict';
+
+var path = require('path');
+var through = require('through2');
+var EOL = require('os').EOL;
+
+module.exports = function concatTransform(name) {
+
+  var concat, firstFile, fileName;
+
+  return through.obj(function transform(file, encoding, next) {
+
+    if (!firstFile) {
+      firstFile = file;
+      // Default path to first file basename
+      fileName = name || path.basename(file.path);
+      // Initialize concat
+      concat = [];
+    }
+
+    concat.push(file.contents);
+    next();
+
+  }, function flush(next) {
+
+    if (firstFile) {
+      var joinedFile = firstFile.clone();
+      joinedFile.path = path.join(firstFile.base, fileName);
+
+      for(var i = 0, l = concat.length; i < l - 1; i++) {
+        concat.splice(i + 1, 0, new Buffer(EOL));
+      }
+      joinedFile.contents = Buffer.concat(concat);
+
+      /* jshint validthis:true */
+      this.push(joinedFile);
+    }
+
+    next();
+
+  });
+
+};


### PR DESCRIPTION
Fixes #55. It required a heavy rewrite of the plugin. Feel free to ask any question about the implementation.

Passes all tests.
