### PR TITLE
support for single quotes

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,8 +10,8 @@ module.exports = function(options) {
   options = options || {};
   var startReg = /<!--\s*build:(\w+)(?:\(([^\)]+?)\))?\s+(\/?([^\s]+?))?\s*-->/gim;
   var endReg = /<!--\s*endbuild\s*-->/gim;
-  var jsReg = /<\s*script\s+.*?src\s*=\s*"([^"]+?)".*?><\s*\/\s*script\s*>/gi;
-  var cssReg = /<\s*link\s+.*?href\s*=\s*"([^"]+)".*?>/gi;
+  var jsReg = /<\s*script\s+.*?src\s*=\s*("|')([^"']+?)\1.*?><\s*\/\s*script\s*>/gi;
+  var cssReg = /<\s*link\s+.*?href\s*=\s*("|')([^"']+)\1.*?>/gi;
   var startCondReg = /<!--\[[^\]]+\]>/gim;
   var endCondReg = /<!\[endif\]-->/gim;
   var basePath, mainPath, mainName, alternatePath;
@@ -41,7 +41,7 @@ module.exports = function(options) {
       .replace(startCondReg, '')
       .replace(endCondReg, '')
       .replace(/<!--(?:(?:.|\r|\n)*?)-->/gim, '')
-      .replace(reg, function (a, b) {
+      .replace(reg, function (a, quote, b) {
         var filePath = path.resolve(path.join(alternatePath || mainPath, b));
 
         if (options.assetsDir)


### PR DESCRIPTION
Hi, 

in HTML you can specify tag attributes using either single quotes or double quotes as in example bellow:

``` html
<!-- build:js /data/js/app.js -->
<script src='js/lib.js'></script>
<script src='js/main.js'></script>
<!-- endbuild -->
```

I have changed the regular expressions to allow any of the styles.

Regards,
Adrian
