### PR TITLE
Use outputRelativePath in referring to built file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "0.11"
+  - "0.10"

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = function(options) {
       var isStatic = name.split('.').pop() === 'js' || name.split('.').pop() === 'css'
 
       if (options.outputRelativePath && isStatic)
-        filePath = options.outputRelativePath + name;
+        filePath = path.join(options.outputRelativePath, name);
 
     return new gutil.File({
       path: filePath,
@@ -146,13 +146,14 @@ module.exports = function(options) {
           if (getBlockType(section[5]) == 'js') {
             process(section[4], getFiles(section[5], jsReg), section[1], function(name, file) {
               push(file);
-              if (path.extname(file.path) == '.js')
-                html.push('<script src="' + name.replace(path.basename(name), path.basename(file.path)) + '"></script>');
+              if (path.extname(file.path) == '.js') {
+                html.push('<script src="' + path.join(options.outputRelativePath || '', name.replace(path.basename(name), path.basename(file.path))) + '"></script>');
+              }
             }.bind(this, section[3]));
           } else {
             process(section[4], getFiles(section[5], cssReg), section[1], function(name, file) {
               push(file);
-              html.push('<link rel="stylesheet" href="' + name.replace(path.basename(name), path.basename(file.path)) + '"' +
+              html.push('<link rel="stylesheet" href="' + path.join(options.outputRelativePath || '', name.replace(path.basename(name), path.basename(file.path))) + '"' +
                         (cssMediaQuery ? ' media="' + cssMediaQuery + '"' : '') +
                         '/>');
             }.bind(this, section[3]));

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
 		"gulp-uglify": "~0.3.1",
 		"gulp-minify-html": "~0.1.1",
 		"gulp-minify-css": "~0.3.0",
-		"gulp-rev": "~0.4.2"
+		"gulp-rev": "~0.4.2",
+		"mocha": "^2.0.1"
 	},
 	"scripts": {
 		"test": "mocha"

--- a/test/expected/output-path/app.js
+++ b/test/expected/output-path/app.js
@@ -1,0 +1,2 @@
+var sample = 111;
+console.log(sample);

--- a/test/expected/output-path/style.css
+++ b/test/expected/output-path/style.css
@@ -1,0 +1,7 @@
+* {
+	margin: 0;
+	padding: 0;
+}
+body {
+	margin: 10px;
+}

--- a/test/expected/simple-css-relative-output-path.html
+++ b/test/expected/simple-css-relative-output-path.html
@@ -1,0 +1,1 @@
+<link rel="stylesheet" href="output-path/style.css"/>

--- a/test/expected/simple-js-relative-output-path.html
+++ b/test/expected/simple-js-relative-output-path.html
@@ -1,0 +1,1 @@
+<script src="output-path/app.js"></script>

--- a/test/fixtures/simple-css-relative-output-path.html
+++ b/test/fixtures/simple-css-relative-output-path.html
@@ -1,0 +1,4 @@
+<!-- build:css /style.css -->
+<link rel="stylesheet" href="css/clear.css"/>
+<link rel="stylesheet" href="css/main.css"/>
+<!-- endbuild -->

--- a/test/fixtures/simple-js-relative-output-path.html
+++ b/test/fixtures/simple-js-relative-output-path.html
@@ -1,0 +1,4 @@
+<!-- build:js app.js -->
+<script src="js/lib.js"></script>
+<script src="js/main.js"></script>
+<!-- endbuild -->

--- a/test/main.js
+++ b/test/main.js
@@ -615,6 +615,58 @@ describe('gulp-usemin', function() {
       });
     });
 
+    describe('outputRelativePath option:', function() {
+      function compare(outputRelativePath, htmlFixtureName, assetFixtureName, done) {
+        var stream = usemin({outputRelativePath: outputRelativePath});
+        var expectedHtmlName = htmlFixtureName;
+        var expectedAssetName = assetFixtureName;
+        var expectedHtmlContents = getExpected(expectedHtmlName).contents;
+        var expectedAssetContents = getExpected(expectedAssetName).contents;
+        var htmlExists = false;
+        var assetExists = false;
+        var callback = function(newFile) {
+          if (newFile.path === expectedHtmlName) {
+            htmlExists = true;
+            assert.equal(String(expectedHtmlContents), String(newFile.contents));
+          }
+          if (newFile.path === expectedAssetName) {
+            assetExists = true;
+            assert.equal(String(expectedAssetContents), String(newFile.contents));
+          }
+        };
+        var end = function() {
+          assert.ok(htmlExists, expectedHtmlName + ' does not exist');
+          assert.ok(assetExists, expectedAssetName + ' does not exist');
+          done();
+        };
+
+        stream.on('data', callback);
+        stream.on('end', end);
+
+        stream.write(getFixture(htmlFixtureName));
+        stream.end();
+      }
+
+      describe('output-path/', function() {
+        it('simple-js.html', function(done) {
+          compare('output-path/', 'simple-js-relative-output-path.html', 'output-path/app.js', done);
+        });
+        it('simple-css.html', function(done) {
+          compare('output-path/', 'simple-css-relative-output-path.html', 'output-path/style.css', done);
+        });
+      });
+
+      describe('output-path', function() {
+        it('simple-js.html', function(done) {
+          compare('output-path', 'simple-js-relative-output-path.html', 'output-path/app.js', done);
+        });
+        it('simple-css.html', function(done) {
+          compare('output-path', 'simple-css-relative-output-path.html', 'output-path/style.css', done);
+        });
+      });
+
+    });
+
     describe('conditional comments:', function() {
       function compare(name, expectedName, done) {
         var stream = usemin();


### PR DESCRIPTION
JS and CSS files were moved correctly into the output dir,
but the script and link tags did not refer to the moved
files.

This fixes that, and makes the script and link tags point
to the file's new path.
