### PR TITLE
Fixed uncatched global `gutil.PluginError` on missing paths and rerouted to the ...

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,7 +186,12 @@ module.exports = function(options) {
       mainPath = path.dirname(file.path);
       mainName = path.basename(file.path);
 
-      processHtml(String(file.contents), this.push.bind(this), callback);
+      try {
+        processHtml(String(file.contents), this.push.bind(this), callback);
+      }catch(err){
+        this.emit('error', err);
+        return callback();
+      }
     }
   });
 };


### PR DESCRIPTION
...gulp error pipeline for non-destructive process continuation.

Scenario: 
If in my watch process usemin is used and a path error is thrown, Gulp exits the process completely due to an uncaught `gutil.PluginError`. This fix catches the error in the through object and emits it appropriately in the gulp error pipeline.