### PR TITLE
Update blocksBuilder.js add dealFilePath option

### DIFF
--- a/lib/blocksBuilder.js
+++ b/lib/blocksBuilder.js
@@ -21,6 +21,14 @@ module.exports = function(file, options) {
   var blocks = [];
   var cssMediaQuery = null;
 
+	function getOutputPath(outputPath){
+		if(options.dealOutputFilePath){
+			return options.dealOutputFilePath(outputPath);
+		}else{
+			return outputPath;
+		}
+	}
+	
   function getFiles(content, reg, alternatePath) {
     var paths = [];
     var files = [];
@@ -85,7 +93,7 @@ module.exports = function(file, options) {
           blocks.push({
             type: section[1].indexOf('inline') !== -1 ? 'inlinejs' : 'js',
             nameInHTML: section[3],
-            name: section[4],
+            name: getOutputPath(section[4]),
             files: getFiles(section[5], jsReg, section[2]),
             tasks: options[section[1]]
           });
@@ -93,7 +101,7 @@ module.exports = function(file, options) {
           blocks.push({
             type: section[1].indexOf('inline') !== -1 ? 'inlinecss' : 'css',
             nameInHTML: section[3],
-            name: section[4],
+            name: getOutputPath(section[4]),
             files: getFiles(section[5], cssReg, section[2]),
             tasks: options[section[1]],
             mediaQuery: cssMediaQuery

--- a/lib/blocksBuilder.js
+++ b/lib/blocksBuilder.js
@@ -37,7 +37,8 @@ module.exports = function(file, options) {
 
         if (options.assetsDir)
           filePath = path.resolve(path.join(options.assetsDir, path.relative(basePath, filePath)));
-
+				if(options.dealFilePath)
+					filePath=options.dealFilePath(filePath);
         paths.push(filePath);
       });
 


### PR DESCRIPTION
add dealFilePath option: it is a function used to change file's find path. for example:
in html a js path is:
	 src="{{path}}/assets/lib/jquery-1.11.0.min.js"
in gulp:
            gulp.src(file).pipe(usemin({
                assetsDir : "src/main/webapp",
                css : [ 'concat', minifyCss(), rev() ],
                js : [ 'concat', uglify({}), rev() ],
                html : [ minifyHtml({
                    empty : true
                }) ],
                dealFilePath : function(filePath) {
                    return filePath.replace("{{path}}", "");
                },
                enableHtmlComment : false,
                outputRelativePath : false,
            })).pipe(gulp.dest(handlebarOutDir + location));