### PR TITLE
Fix multiple tasks under the tasks to be changed

### DIFF
--- a/lib/blocksBuilder.js
+++ b/lib/blocksBuilder.js
@@ -86,7 +86,7 @@ module.exports = function(file, options) {
             nameInHTML: section[3],
             name: section[4],
             files: getFiles(section[5], jsReg, section[2]),
-            tasks: options[section[1]]
+            tasks: options[section[1]].slice(0)
           });
         } else {
           blocks.push({
@@ -94,7 +94,7 @@ module.exports = function(file, options) {
             nameInHTML: section[3],
             name: section[4],
             files: getFiles(section[5], cssReg, section[2]),
-            tasks: options[section[1]],
+            tasks: options[section[1]].slice(0),
             mediaQuery: cssMediaQuery
           });
         }


### PR DESCRIPTION
index1.html

```html
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <title>test1</title>
</head>
<body>
</body>
    <!-- build:inlinejs -->
    <script src="a.js"></script>
    <!-- endbuild -->
    <script>
    var c = 303030;
    </script>
</html>
```

index2.html

```html
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <title>test2</title>
</head>
<body>
    <!-- build:inlinejs -->
    <script src="b.js"></script>
    <!-- endbuild -->
</body>
</html>
```

gulpfile.js

```
gulp.task('default', function() {
    return gulp.src(['index1.html', 'index2.html'])
        .pipe($.usemin({
            outputRelativePath: '',
            path: '',
            inlinejs: []
        }))
        .pipe(gulp.dest('dist'))
        .pipe($.size());
})
```

If the task set to any value including [], index2.html b.js content will be replaced by the content of the a.js, Because the options of task was changed