### PR TITLE
gulp-foreach example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,20 +17,28 @@ Then, add it to your `gulpfile.js`:
 ```javascript
 var usemin = require('gulp-usemin');
 var uglify = require('gulp-uglify');
+var foreach = require('gulp-foreach');
 var minifyHtml = require('gulp-minify-html');
 var minifyCss = require('gulp-minify-css');
 var rev = require('gulp-rev');
 
-gulp.task('usemin', function () {
+/*
+ * foreach is because usemin 0.3.11 won't manipulate
+ * multiple files as an array.
+ */
+gulp.task('usemin', function() {
   return gulp.src('./*.html')
-      .pipe(usemin({
-        css: [minifyCss(), 'concat'],
-        html: [minifyHtml({empty: true})],
-        js: [uglify(), rev()],
-        inlinejs: [uglify()],
-        inlinecss: [minifyCss(), 'concat']
-      }))
-      .pipe(gulp.dest('build/'));
+    .pipe(foreach(function(stream, file) {
+      return stream
+        .pipe(usemin({
+          css: [ rev() ],
+          html: [ minifyHtml({ empty: true }) ],
+          js: [ uglify(), rev() ],
+          inlinejs: [ uglify() ],
+          inlinecss: [ minifyCss(), 'concat' ]
+        }))
+        .pipe(gulp.dest('build/'));
+    }));
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"gulp-util": "~2.2.14",
 		"gulp-uglify": "~0.3.1",
 		"gulp-minify-html": "~0.1.1",
+		"gulp-foreach": "~0.1.0",
 		"gulp-minify-css": "~0.3.0",
 		"gulp-rev": "~0.4.2",
 		"gulp-less": "2.0.1"


### PR DESCRIPTION
adds ``gulp-foreach`` until there's a better approach. This can also help alleviate authors from digging deep in the issue tracker for a solution.