### PR TITLE
Replace block functionality.

### DIFF
--- a/lib/blocksBuilder.js
+++ b/lib/blocksBuilder.js
@@ -22,7 +22,11 @@ module.exports = function(file, options) {
   var blocks = [];
   var cssMediaQuery = null;
 
-  function getFiles(content, reg, alternatePath) {
+  function getFiles(type, content, reg, alternatePath) {
+
+    if (type.indexOf("replace") !== -1)
+      return [];
+    
     var paths = [];
     var files = [];
     cssMediaQuery = null;
@@ -86,20 +90,23 @@ module.exports = function(file, options) {
         blocks.push(startCondLine[0]);
 
       if (section[1] !== 'remove') {
+        var type;
         if (jsReg.test(section[5])) {
+          type = section[1].indexOf('inline') !== -1 ? 'inlinejs' : section[1].indexOf('replace') !== -1 ? 'replacejs' : 'js';
           blocks.push({
-            type: section[1].indexOf('inline') !== -1 ? 'inlinejs' : 'js',
+            type: type,
             nameInHTML: section[3],
             name: outputPath + section[4],
-            files: getFiles(section[5], jsReg, section[2]),
+            files: getFiles(type, section[5], jsReg, section[2]),
             tasks: options[section[1]]
           });
         } else {
+          type = section[1].indexOf('inline') !== -1 ? 'inlinecss' : section[1].indexOf('replace') !== -1 ? 'replacecss' : 'css';
           blocks.push({
-            type: section[1].indexOf('inline') !== -1 ? 'inlinecss' : 'css',
+            type: type,
             nameInHTML: section[3],
             name: outputPath + section[4],
-            files: getFiles(section[5], cssReg, section[2]),
+            files: getFiles(type, section[5], cssReg, section[2]),
             tasks: options[section[1]],
             mediaQuery: cssMediaQuery
           });

--- a/lib/blocksBuilder.js
+++ b/lib/blocksBuilder.js
@@ -96,7 +96,7 @@ module.exports = function(file, options) {
           blocks.push({
             type: type,
             nameInHTML: section[3],
-            name: outputPath + section[4],
+            name: path.join(outputPath, section[4]),
             files: getFiles(type, section[5], jsReg, section[2]),
             tasks: options[section[1]]
           });
@@ -105,7 +105,7 @@ module.exports = function(file, options) {
           blocks.push({
             type: type,
             nameInHTML: section[3],
-            name: outputPath + section[4],
+            name: path.join(outputPath, section[4]),
             files: getFiles(type, section[5], cssReg, section[2]),
             tasks: options[section[1]],
             mediaQuery: cssMediaQuery

--- a/lib/htmlBuilder.js
+++ b/lib/htmlBuilder.js
@@ -51,6 +51,14 @@ module.exports = function(file, blocks, options, push, callback) {
           resolve();
         }.bind(this));
       }
+      else if (block.type == 'replacejs') {
+        html[i] = '<script src="' + block.nameInHTML + '"></script>';
+        resolve();
+      }
+      else if (block.type == 'replacecss') {
+        html[i] = '<link rel="stylesheet" type="text/css" href="' + block.nameInHTML + '" />';
+        resolve();
+      }
     });
   });
 


### PR DESCRIPTION
Hi!

This PR is suggestion for a simple feature I needed for my workflow.

Example:
```html
<!-- build:replacejs /video.bundle.js -->
<script src="/getjs/video"></script>
<!-- endbuild -->
```

Resolves to this:
```html
<script src="/video.bundle.js"></script>
```

What do you think?