### PR TITLE
Allow proper html output when blocks are empty

### DIFF
--- a/lib/htmlBuilder.js
+++ b/lib/htmlBuilder.js
@@ -22,6 +22,9 @@ module.exports = function(file, blocks, options, push, callback) {
         html[i] = block;
         resolve();
       }
+      else if (block.files.length == 0){
+        resolve();
+      }
       else if (block.type == 'js') {
         pipeline(block.name, block.files, block.tasks, function(name, file) {
           push(file);


### PR DESCRIPTION
When any of the build blocks didn't contain files the process didn't output the whole html. With this tweak it becomes more resilient by accepting empty blocks also.