### PR TITLE
Added feature to assign attributes to js script tags (Solves #52, #75, #77 )

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,31 @@ Type: `Boolean`
 
 Keep HTML comment when processing
 
+#### jsAttributes
+Type: `Object`
+
+Attach HTML attributes to the output js file.
+For Example :
+```js
+gulp.task('usemin', function() {
+  return gulp.src('./index.html')
+    .pipe(usemin({
+      html: [],
+      jsAttributes : {
+        async : true,
+        lorem : 'ipsum'
+      },
+      js: [ ]
+    }))
+    .pipe(gulp.dest('./'));
+});
+```
+Will give you :
+```html
+<script src="./lib.js" async lorem="ipsum" ></script>
+```
+As your built script tag.
+
 ## Use case
 
 ```

--- a/lib/htmlBuilder.js
+++ b/lib/htmlBuilder.js
@@ -19,14 +19,14 @@ module.exports = function(file, blocks, options, push, callback) {
     attributes = attributes || {};
     var attrString = ' ';
     Object.keys(attributes).forEach(function(attribute){
-      if(attribute === true){
+      if(attributes[attribute] === true){
         attrString += attribute + ' ';
         return;
       }
-      if(attribute === false){
+      if(attributes[attribute] === false){
         return;
       }
-      attrString += attribute + '=' + attributes[attribute] + ' ';
+      attrString += attribute + '="' + attributes[attribute] + '" ';
     });
     return attrString;
   }
@@ -45,7 +45,7 @@ module.exports = function(file, blocks, options, push, callback) {
         pipeline(block.name, block.files, block.tasks, function(name, file) {
           push(file);
           if (path.extname(file.path) == '.js')
-            html[i] = '<script src="' + name.replace(path.basename(name), path.basename(file.path)) + createHTMLAttributes(options.jsAttributes) + '"></script>';
+            html[i] = '<script src="' + name.replace(path.basename(name), path.basename(file.path)) +  '"' + createHTMLAttributes(options.jsAttributes) +'></script>';
           resolve();
         }.bind(this, block.nameInHTML));
       }

--- a/lib/htmlBuilder.js
+++ b/lib/htmlBuilder.js
@@ -15,6 +15,22 @@ module.exports = function(file, blocks, options, push, callback) {
     })
   }
 
+  function createHTMLAttributes(attributes){
+    attributes = attributes || {};
+    var attrString = ' ';
+    Object.keys(attributes).forEach(function(attribute){
+      if(attribute === true){
+        attrString += attribute + ' ';
+        return;
+      }
+      if(attribute === false){
+        return;
+      }
+      attrString += attribute + '=' + attributes[attribute] + ' ';
+    });
+    return attrString;
+  }
+
   var html = [];
   var promises = blocks.map(function(block, i) {
     return new Promise(function(resolve) {
@@ -29,7 +45,7 @@ module.exports = function(file, blocks, options, push, callback) {
         pipeline(block.name, block.files, block.tasks, function(name, file) {
           push(file);
           if (path.extname(file.path) == '.js')
-            html[i] = '<script src="' + name.replace(path.basename(name), path.basename(file.path)) + '"></script>';
+            html[i] = '<script src="' + name.replace(path.basename(name), path.basename(file.path)) + createHTMLAttributes(options.jsAttributes) + '"></script>';
           resolve();
         }.bind(this, block.nameInHTML));
       }

--- a/lib/htmlBuilder.js
+++ b/lib/htmlBuilder.js
@@ -16,7 +16,9 @@ module.exports = function(file, blocks, options, push, callback) {
   }
 
   function createHTMLAttributes(attributes){
-    attributes = attributes || {};
+    if(!attributes){
+      return '';
+    }
     var attrString = ' ';
     Object.keys(attributes).forEach(function(attribute){
       if(attributes[attribute] === true){
@@ -44,8 +46,9 @@ module.exports = function(file, blocks, options, push, callback) {
       else if (block.type == 'js') {
         pipeline(block.name, block.files, block.tasks, function(name, file) {
           push(file);
+          var jsAttributes = options ? options.jsAttributes : null;
           if (path.extname(file.path) == '.js')
-            html[i] = '<script src="' + name.replace(path.basename(name), path.basename(file.path)) +  '"' + createHTMLAttributes(options.jsAttributes) +'></script>';
+            html[i] = '<script src="' + name.replace(path.basename(name), path.basename(file.path)) +  '"' + createHTMLAttributes(jsAttributes) +'></script>';
           resolve();
         }.bind(this, block.nameInHTML));
       }


### PR DESCRIPTION
Added functionality to attach HTML attributes to the output js file.
For Example :
```js
gulp.task('usemin', function() {
  return gulp.src('./index.html')
    .pipe(usemin({
      html: [],
      jsAttributes : {
        async : true,
        lorem : 'ipsum'
      },
      js: [ ]
    }))
    .pipe(gulp.dest('./'));
});
```
Will give you :
```html
<script src="./lib.js" async lorem="ipsum" ></script>
```
As your built script tag.
 (Solves #52 , #75 , #77  )