### PR TITLE
Add cacheBuster option

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,11 @@ Will give you :
 ```
 As your built script tag.
 
+#### cacheBuster
+Type: `Boolean`
+
+Insert a timestamp into the output file names to prevent the browser from using an cached older version.
+
 ## Use case
 
 ```

--- a/lib/blocksBuilder.js
+++ b/lib/blocksBuilder.js
@@ -21,6 +21,12 @@ module.exports = function(file, options) {
   var sections = content.split(endReg);
   var blocks = [];
   var cssMediaQuery = null;
+  var cacheBusterSuffix = options.cacheBuster ? '.' + Date.now() : '';
+
+  function addCacheBuster(filePath) {
+    var ext = path.extname(filePath);
+    return filePath.slice(0, -ext.length) + cacheBusterSuffix + ext;
+  }
 
   function getFiles(content, reg, alternatePath) {
     var paths = [];
@@ -90,7 +96,7 @@ module.exports = function(file, options) {
           blocks.push({
             type: section[1].indexOf('inline') !== -1 ? 'inlinejs' : 'js',
             nameInHTML: section[3],
-            name: outputPath + section[4],
+            name: addCacheBuster(outputPath + section[4]),
             files: getFiles(section[5], jsReg, section[2]),
             tasks: options[section[1]]
           });
@@ -98,7 +104,7 @@ module.exports = function(file, options) {
           blocks.push({
             type: section[1].indexOf('inline') !== -1 ? 'inlinecss' : 'css',
             nameInHTML: section[3],
-            name: outputPath + section[4],
+            name: addCacheBuster(outputPath + section[4]),
             files: getFiles(section[5], cssReg, section[2]),
             tasks: options[section[1]],
             mediaQuery: cssMediaQuery

--- a/lib/blocksBuilder.js
+++ b/lib/blocksBuilder.js
@@ -25,6 +25,9 @@ module.exports = function(file, options) {
 
   function addCacheBuster(filePath) {
     var ext = path.extname(filePath);
+    if (ext.length === 0) {
+      return filePath + cacheBusterSuffix;
+    }
     return filePath.slice(0, -ext.length) + cacheBusterSuffix + ext;
   }
 


### PR DESCRIPTION
When `cacheBuster` is set to true, it will insert a timestamp into the script name.

Example: `js/scripts.js` => `js/scripts.1449243640240.js`

Thoughts?