### PR TITLE
add pathReplace option to replace substring in source script file path

### DIFF
--- a/lib/blocksBuilder.js
+++ b/lib/blocksBuilder.js
@@ -59,6 +59,9 @@ module.exports = function(file, options) {
     }
 
     for (var i = 0, l = paths.length; i < l; ++i) {
+      if (options.pathReplace)
+        paths[i] = paths[i].replace(options.pathReplace, '');
+
       var filepaths = glob.sync(paths[i]);
       if(filepaths[0] === undefined) {
         throw new gutil.PluginError('gulp-usemin', 'Path ' + paths[i] + ' not found!');


### PR DESCRIPTION
Useful if you use get param to prevent file caching:
```
<!-- build:js /static/scripts/widget.min.js -->
<script src="/static/scripts/widget/i18n.js?{{REVISION}}"></script>
<script src="/static/scripts/widget/main.js?{{REVISION}}"></script>
<!-- endbuild -->
```

```
usemin({
      path: '../',
      pathReplace: '?{{REVISION}}',
      outputRelativePath: '../',
      js: [uglify()]
})
```

If __pathReplace__ option is set, usemin searches for `../static/scripts/widget/i18n.js` and `../static/scripts/widget/main.js`.

pathReplace either could be string or regex