### PR TITLE
support array value for jsAttributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ gulp.task('usemin', function() {
       html: [],
       jsAttributes : {
         async : true,
-        lorem : 'ipsum'
+        lorem : 'ipsum',
+        seq   : [1, 2, 1]
       },
       js: [ ]
     }))
@@ -151,7 +152,9 @@ gulp.task('usemin', function() {
 ```
 Will give you :
 ```html
-<script src="./lib.js" async lorem="ipsum" ></script>
+<script src="./lib.js" async lorem="ipsum" seq="1"></script>
+<script src="./app.js" async lorem="ipsum" seq="2"></script>
+<script src="./extra.js" async lorem="ipsum" seq="1"></script>
 ```
 As your built script tag.
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,9 @@ gulp.task('usemin', function() {
         lorem : 'ipsum',
         seq   : [1, 2, 1]
       },
-      js: [ ]
+      js: [ ],
+      js1:[ ],
+      js2:[ ]
     }))
     .pipe(gulp.dest('./'));
 });

--- a/lib/htmlBuilder.js
+++ b/lib/htmlBuilder.js
@@ -19,13 +19,13 @@ module.exports = function(file, blocks, options, push, callback) {
     if(!attributes){
       return '';
     }
-    var attrString = ' ';
+    var attrArray = [];
     Object.keys(attributes).forEach(function (attribute) {
 
       var attributeValue = attributes[attribute];
 
       if (attributeValue === true) {
-        attrString += attribute + ' ';
+        attrArray.push(attribute);
         return;
       }
       if (attributeValue === false) {
@@ -33,13 +33,13 @@ module.exports = function(file, blocks, options, push, callback) {
       }
 
       if (Array.isArray(attributeValue)) {
-        attrString += attribute + '="' + attributeValue[index] + '" ';
+        attrArray.push(attribute + '="' + attributeValue[index] + '"');
       } else {
-        attrString += attribute + '="' + attributeValue + '" ';
+        attrArray.push(attribute + '="' + attributeValue + '"');
       }
 
     });
-    return attrString;
+    return ' ' + attrArray.join(' ');
   }
 
   var html = [];

--- a/lib/htmlBuilder.js
+++ b/lib/htmlBuilder.js
@@ -15,25 +15,35 @@ module.exports = function(file, blocks, options, push, callback) {
     })
   }
 
-  function createHTMLAttributes(attributes){
+  function createHTMLAttributes(attributes, index){
     if(!attributes){
       return '';
     }
     var attrString = ' ';
-    Object.keys(attributes).forEach(function(attribute){
-      if(attributes[attribute] === true){
+    Object.keys(attributes).forEach(function (attribute) {
+
+      var attributeValue = attributes[attribute];
+
+      if (attributeValue === true) {
         attrString += attribute + ' ';
         return;
       }
-      if(attributes[attribute] === false){
+      if (attributeValue === false) {
         return;
       }
-      attrString += attribute + '="' + attributes[attribute] + '" ';
+
+      if (Array.isArray(attributeValue)) {
+        attrString += attribute + '="' + attributeValue[index] + '" ';
+      } else {
+        attrString += attribute + '="' + attributeValue + '" ';
+      }
+
     });
     return attrString;
   }
 
   var html = [];
+  var jsCounter = 0;
   var promises = blocks.map(function(block, i) {
     return new Promise(function(resolve) {
       if (typeof block == 'string') {
@@ -48,7 +58,7 @@ module.exports = function(file, blocks, options, push, callback) {
           push(file);
           var jsAttributes = options ? options.jsAttributes : null;
           if (path.extname(file.path) == '.js')
-            html[i] = '<script src="' + name.replace(path.basename(name), path.basename(file.path)) +  '"' + createHTMLAttributes(jsAttributes) +'></script>';
+            html[i] = '<script src="' + name.replace(path.basename(name), path.basename(file.path)) +  '"' + createHTMLAttributes(jsAttributes, jsCounter++) +'></script>';
           resolve();
         }.bind(this, block.nameInHTML));
       }

--- a/test/expected/array-js-attributes.html
+++ b/test/expected/array-js-attributes.html
@@ -1,0 +1,7 @@
+<script src="/dist/index.js" seq="1" color="blue"></script>
+
+<script src="/dist/index1.js" seq="2" color="red"></script>
+
+<script src="/dist/index2.js" seq="1" color="yellow"></script>
+
+<script src="/dist/index3.js" seq="3" color="pink"></script>

--- a/test/fixtures/array-js-attributes.html
+++ b/test/fixtures/array-js-attributes.html
@@ -1,0 +1,15 @@
+<!--build:js /dist/index.js -->
+<script src="js/lib.js"></script>
+<!--endbuild-->
+
+<!--build:js1 /dist/index1.js -->
+<script src="js/main.js"></script>
+<!--endbuild-->
+
+<!--build:js2 /dist/index2.js -->
+<script src="js2/lib2.js"></script>
+<!--endbuild-->
+
+<!--build:js3 /dist/index3.js -->
+<script src="js2/main2.js"></script>
+<!--endbuild-->

--- a/test/main.js
+++ b/test/main.js
@@ -593,6 +593,37 @@ describe('gulp-usemin', function() {
 
     });
 
+    describe('array jsAttributes:', function() {
+
+      function compare(fixtureName, name, end) {
+        var stream = usemin({
+          jsAttributes: {
+            seq: [1, 2, 1, 3],
+            color: ['blue', 'red', 'yellow', 'pink']
+          },
+          js: [],
+          js1: [],
+          js2: [],
+          js3: []
+
+        });
+
+        stream.on('data', function(newFile) {
+          if (path.basename(newFile.path) === name) {
+            assert.equal(String(newFile.contents), String(getExpected(name).contents));
+            end();
+          }
+        });
+
+        stream.write(getFixture(fixtureName));
+      }
+
+      it('js attributes with array define', function (done) {
+        compare('array-js-attributes.html', 'array-js-attributes.html', done);
+      });
+
+    });
+
     it('async task', function(done) {
       var less = require('gulp-less');
       var cssmin = require('gulp-minify-css');


### PR DESCRIPTION
I had made a script loader to load scripts by reading html template,so I have to mark the order of script.  
for example, original html template:
```html
<!--build:js index.js -->
<script src="a.js"></script>
<script src="b.js"></script>
<!--endbuild-->

<!--build:js app.js -->
<script src="c.js"></script>
<script src="d.js"></script>
<!--endbuild-->
```
so I add a support for jsAttributes config
```js
jsAttributes:{
  seq : [3, 1]
}
```
will gives:
```html
<script src="index.js" seq="3"></script>
<script src="app.js" seq="1"></script>
```
the seq value added by appear order in html

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/zont/gulp-usemin/157)
<!-- Reviewable:end -->
