### PR TITLE
Fixed block output when stream returns multiple files

### DIFF
--- a/lib/htmlBuilder.js
+++ b/lib/htmlBuilder.js
@@ -36,6 +36,7 @@ module.exports = function(file, blocks, options, push, callback) {
   var html = [];
   var promises = blocks.map(function(block, i) {
     return new Promise(function(resolve) {
+      html[i] = '';
       if (typeof block == 'string') {
         html[i] = block;
         resolve();
@@ -48,14 +49,14 @@ module.exports = function(file, blocks, options, push, callback) {
           push(file);
           var jsAttributes = options ? options.jsAttributes : null;
           if (path.extname(file.path) == '.js')
-            html[i] = '<script src="' + name.replace(path.basename(name), path.basename(file.path)) +  '"' + createHTMLAttributes(jsAttributes) +'></script>';
+            html[i] += '<script src="' + name.replace(path.basename(name), path.basename(file.path)) +  '"' + createHTMLAttributes(jsAttributes) +'></script>';
           resolve();
         }.bind(this, block.nameInHTML));
       }
       else if (block.type == 'css') {
         pipeline(block.name, block.files, block.tasks, function(name, file) {
           push(file);
-          html[i] = '<link rel="stylesheet" href="' + name.replace(path.basename(name), path.basename(file.path)) + '"'
+          html[i] += '<link rel="stylesheet" href="' + name.replace(path.basename(name), path.basename(file.path)) + '"'
             + (block.mediaQuery ? ' media="' + block.mediaQuery + '"' : '') + '/>';
           resolve();
         }.bind(this, block.nameInHTML));

--- a/test/expected/multiple-files.html
+++ b/test/expected/multiple-files.html
@@ -1,0 +1,3 @@
+<link rel="stylesheet" href="data/css/style.css"/><link rel="stylesheet" href="data/css/style.css"/>
+
+<script src="/data/js/app.js"></script><script src="/data/js/app.js"></script>

--- a/test/fixtures/multiple-files.html
+++ b/test/fixtures/multiple-files.html
@@ -1,0 +1,9 @@
+<!-- build:css data/css/style.css -->
+<link rel="stylesheet" href="css/clear.css"/>
+<link rel="stylesheet" href="css/main.css"/>
+<!-- endbuild -->
+
+<!-- build:js /data/js/app.js -->
+<script src="js/lib.js"></script>
+<script src="js/main.js"></script>
+<!-- endbuild -->

--- a/test/main.js
+++ b/test/main.js
@@ -613,4 +613,42 @@ describe('gulp-usemin', function() {
       stream.write(getFixture('async-less.html'));
     });
   });
+
+  it('multiple files in stream', function(done) {
+    var multipleFiles = function() {
+      var through = require('through2');
+      var File = gutil.File;
+
+      return through.obj(function(file, enc, cb) {
+        var stream = this;
+
+        stream.push(new File({
+          cwd: file.cwd,
+          base: file.base,
+          path: file.path,
+          contents: new Buffer('test1')
+        }));
+
+        stream.push(new File({
+          cwd: file.cwd,
+          base: file.base,
+          path: file.path,
+          contents: new Buffer('test2')
+        }));
+      });
+    };
+    var stream = usemin({
+      css: [multipleFiles],
+      js: [multipleFiles]
+    });
+
+    stream.on('data', function(newFile) {
+      if (path.basename(newFile.path) === path.basename('multiple-files.html')) {
+        assert.equal(String(getExpected('multiple-files.html').contents), String(newFile.contents));
+        done();
+      }
+    });
+
+    stream.write(getFixture('multiple-files.html'));
+  });
 });


### PR DESCRIPTION
When stream returns multiple files, they are lost in block output, since they are overwritten by index on every iteration. This allows to use gulp-bless together with gulp-usemin.