### PR TITLE
add pathTransform option

### DIFF
--- a/lib/blocksBuilder.js
+++ b/lib/blocksBuilder.js
@@ -59,6 +59,9 @@ module.exports = function(file, options) {
     }
 
     for (var i = 0, l = paths.length; i < l; ++i) {
+      if (options.pathTransform && typeof options.pathTransform === 'function') {
+        paths[i] = options.pathTransform(paths[i]);
+      }
       var filepaths = glob.sync(paths[i]);
       if(filepaths[0] === undefined) {
         throw new gutil.PluginError('gulp-usemin', 'Path ' + paths[i] + ' not found!');


### PR DESCRIPTION
In build block I've got source files paths that don't match real files. I.e. with added revision in a template.
```html
<!-- build:js static/scripts/app.min.js -->
    <script src="static/scripts/app.js?{{REVISION}}"></script>
    <script src="static/scripts/utils/filters/truncatechars.js?{{REVISION}}"></script>
    .
    .
    .
<!-- endbuild -->
```
In that case gulp-usemin doesn't find source files and fails. 
pathTransform option is a function that transforms source file string to make it match the real path.
__It doesn't transform destination file path__.
```javascript
gulp.task('build', function() {
  return gulp.src('index.html')
    .pipe(gulp-usemin({
        path: './',
        pathTransform: function(path) {
          return path.replace('?{{REVISION}}', '');
        },
        js: [uglify()],
     }))
     .pipe(gulp.dest('./');
});
```