### PR TITLE
adding pre and post processing path file hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,25 @@ This will generate the following output:
     <script src="js/optimized.js"></script>
 ```
 
+#### preprocessPath
+Type: `Function`
+
+Arguments: `String:filePath`
+
+Return a string that gets used before usemin fetches files
+
+#### generatedUrl
+Type: `Function`
+
+Arguments: `String:name`, `Path:path`, `File:file`
+
+Default:
+```
+function(name, path, file){
+  return name.replace(path.basename(name), path.basename(file.path))
+};
+```
+
 ## Changelog
 
 #####0.3.21

--- a/lib/blocksBuilder.js
+++ b/lib/blocksBuilder.js
@@ -42,6 +42,10 @@ module.exports = function(file, options) {
         if (options.assetsDir)
           filePath = path.resolve(path.join(options.assetsDir, path.relative(basePath, filePath)));
 
+        if( options.preprocessPath ){
+          filePath = options.preprocessPath(filePath);
+        }
+
         paths.push(filePath);
       });
 

--- a/lib/htmlBuilder.js
+++ b/lib/htmlBuilder.js
@@ -7,6 +7,10 @@ module.exports = function(file, blocks, options, push, callback) {
   var name = path.basename(file.path);
   var mainPath = path.dirname(file.path);
 
+  var fileTemplateGenerator = options.generatedUrl || function(name, path, file){
+    return name.replace(path.basename(name), path.basename(file.path))
+  };
+
   function createFile(name, content) {
     var filePath = path.join(path.relative(basePath, mainPath), name);
     return new gutil.File({
@@ -59,14 +63,14 @@ module.exports = function(file, blocks, options, push, callback) {
           push(file);
           var jsAttributes = options ? options.jsAttributes : null;
           if (path.extname(file.path) == '.js')
-            html[i] += '<script src="' + name.replace(path.basename(name), path.basename(file.path)) +  '"' + createHTMLAttributes(jsAttributes, jsCounter++) +'></script>';
+            html[i] += '<script src="' + fileTemplateGenerator(name, path, file) +  '"' + createHTMLAttributes(jsAttributes, jsCounter++) +'></script>';
           resolve();
         }.bind(this, block.nameInHTML));
       }
       else if (block.type == 'css') {
         pipeline(block.name, block.files, block.tasks, function(name, file) {
           push(file);
-          html[i] += '<link rel="stylesheet" href="' + name.replace(path.basename(name), path.basename(file.path)) + '"'
+          html[i] += '<link rel="stylesheet" href="' + fileTemplateGenerator(name, path, file) + '"'
             + (block.mediaQuery ? ' media="' + block.mediaQuery + '"' : '') + '/>';
           resolve();
         }.bind(this, block.nameInHTML));


### PR DESCRIPTION
Since we are running behind a proxy we had the need to programmatically change where usemin looks for the source file and where it outputs the destination in the tags. 

We added file path pre- and post-processing hooks to accomplish this. It should be backwards compatible