### PR TITLE
Option to skip missing resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ Will give you :
 ```
 As your built script tag.
 
+#### skipMissingResources
+Type: `Boolean`
+
+Allows missing resources to be skipped, instead of throwing an error.
+
 ## Use case
 
 ```

--- a/lib/blocksBuilder.js
+++ b/lib/blocksBuilder.js
@@ -60,15 +60,16 @@ module.exports = function(file, options) {
 
     for (var i = 0, l = paths.length; i < l; ++i) {
       var filepaths = glob.sync(paths[i]);
-      if(filepaths[0] === undefined) {
+      if(filepaths[0] === undefined && !options.skipMissingResources) {
         throw new gutil.PluginError('gulp-usemin', 'Path ' + paths[i] + ' not found!');
+      } else {
+        filepaths.forEach(function (filepath) {
+          files.push(new gutil.File({
+            path: filepath,
+            contents: fs.readFileSync(filepath)
+          }));
+        });
       }
-      filepaths.forEach(function (filepath) {
-        files.push(new gutil.File({
-          path: filepath,
-          contents: fs.readFileSync(filepath)
-        }));
-      });
     }
 
     return files;


### PR DESCRIPTION
Allow developer to set option `skipMissingResources` to skip missing resources during processing... instead of throwing an error.