### PR TITLE
Replace deprecated package

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Then, add it to your `gulpfile.js`:
 ```javascript
 var usemin = require('gulp-usemin');
 var uglify = require('gulp-uglify');
-var minifyHtml = require('gulp-minify-html');
+var htmlmin = require('gulp-htmlmin');
 var minifyCss = require('gulp-minify-css');
 var rev = require('gulp-rev');
 
@@ -28,7 +28,7 @@ gulp.task('usemin', function() {
   return gulp.src('./*.html')
     .pipe(usemin({
       css: [ rev() ],
-      html: [ minifyHtml({ empty: true }) ],
+      html: [ htmlmin({ collapseWhitespace: true }) ],
       js: [ uglify(), rev() ],
       inlinejs: [ uglify() ],
       inlinecss: [ minifyCss(), 'concat' ]
@@ -44,7 +44,7 @@ gulp.task('usemin', function() {
   return gulp.src('./*.html')
     .pipe(usemin({
       css: [ rev ],
-      html: [ function () {return minifyHtml({ empty: true });} ],
+      html: [ function () {return htmlmin({ collapseWhitespace: true });} ],
       js: [ uglify, rev ],
       inlinejs: [ uglify ],
       inlinecss: [ minifyCss, 'concat' ]

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"gulp-jshint": "~1.7.0",
 		"gulp-mocha": "~0.5.1",
 		"gulp-uglify": "~0.3.1",
-		"gulp-minify-html": "~0.1.1",
+		"gulp-htmlmin": "^3.0.0",
 		"gulp-minify-css": "~0.3.0",
 		"gulp-rev": "~0.4.2",
 		"gulp-less": "2.0.1"

--- a/test/main.js
+++ b/test/main.js
@@ -30,8 +30,8 @@ function getExpected(filePath) {
 describe('gulp-usemin', function() {
   describe('allow removal sections', function() {
       function compare(name, expectedName, done) {
-        var htmlmin = require('gulp-minify-html');
-        var stream = usemin({html: [htmlmin({empty: true, quotes: true})]});
+        var htmlmin = require('gulp-htmlmin');
+        var stream = usemin({html: [htmlmin({collapseWhitespace: true})]});
 
         stream.on('data', function(newFile) {
           if (path.basename(newFile.path) === name) {
@@ -104,10 +104,10 @@ describe('gulp-usemin', function() {
   describe('should work in buffer mode with', function() {
     describe('minified HTML:', function() {
       function compare(name, expectedName, done, fail) {
-        var htmlmin = require('gulp-minify-html');
+        var htmlmin = require('gulp-htmlmin');
         var stream = usemin({
           html: [function() {
-            return htmlmin({empty: true});
+            return htmlmin({collapseWhitespace: true, removeAttributeQuotes: true});
           }]
         });
 


### PR DESCRIPTION
- Replace `gulp-minify-html` with `gulp-htmlmin` as per suggestion on
npm https://www.npmjs.com/package/gulp-minify-html
- Fix broken tests