### PR TITLE
Update package dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,9 @@ This will generate the following output:
 
 ## Changelog
 
+#####0.3.28
+- Update dependancies and replace deprecated packages (by JamyGolden)
+
 #####0.3.27
 - Updated glob dependency (by icholy)
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Then, add it to your `gulpfile.js`:
 var usemin = require('gulp-usemin');
 var uglify = require('gulp-uglify');
 var htmlmin = require('gulp-htmlmin');
-var minifyCss = require('gulp-minify-css');
+var cleanCss = require('gulp-clean-css');
 var rev = require('gulp-rev');
 
 
@@ -31,7 +31,7 @@ gulp.task('usemin', function() {
       html: [ htmlmin({ collapseWhitespace: true }) ],
       js: [ uglify(), rev() ],
       inlinejs: [ uglify() ],
-      inlinecss: [ minifyCss(), 'concat' ]
+      inlinecss: [ cleanCss(), 'concat' ]
     }))
     .pipe(gulp.dest('build/'));
 });
@@ -47,7 +47,7 @@ gulp.task('usemin', function() {
       html: [ function () {return htmlmin({ collapseWhitespace: true });} ],
       js: [ uglify, rev ],
       inlinejs: [ uglify ],
-      inlinecss: [ minifyCss, 'concat' ]
+      inlinecss: [ cleanCss, 'concat' ]
     }))
     .pipe(gulp.dest('build/'));
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gulp-usemin",
-	"version": "0.3.27",
+	"version": "0.3.28",
 	"description": "Replaces references to non-optimized scripts or stylesheets into a set of HTML files (or any templates/views).",
 	"main": "index.js",
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,22 +4,23 @@
 	"description": "Replaces references to non-optimized scripts or stylesheets into a set of HTML files (or any templates/views).",
 	"main": "index.js",
 	"dependencies": {
-		"gulp-util": "~2.2.14",
-		"through2": "~0.5.1",
-		"glob": "^7.1.1",
-		"gulp-concat": "~2.4.1"
+		"gulp-util": "~3.0.8",
+		"through2": "~2.0.3",
+		"glob": "~7.1.1",
+		"gulp-concat": "~2.6.1"
 	},
 	"devDependencies": {
-		"event-stream": "~3.1.0",
-		"vinyl-fs": "~2.3.1",
-		"gulp": "~3.8.6",
-		"gulp-jshint": "~1.7.0",
-		"gulp-mocha": "~0.5.1",
-		"gulp-uglify": "~0.3.1",
-		"gulp-htmlmin": "^3.0.0",
-		"gulp-clean-css": "^2.3.2",
-		"gulp-rev": "~0.4.2",
-		"gulp-less": "2.0.1"
+		"event-stream": "~3.3.4",
+		"vinyl-fs": "~2.4.4",
+		"gulp": "~3.9.1",
+		"gulp-jshint": "~2.0.4",
+		"gulp-mocha": "~3.0.1",
+		"gulp-uglify": "~2.0.1",
+		"gulp-htmlmin": "~3.0.0",
+		"gulp-clean-css": "~2.3.2",
+		"gulp-rev": "~7.1.2",
+		"gulp-less": "3.3.0",
+		"jshint": "~2.9.4"
 	},
 	"scripts": {
 		"test": "./node_modules/.bin/gulp"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"gulp-mocha": "~0.5.1",
 		"gulp-uglify": "~0.3.1",
 		"gulp-htmlmin": "^3.0.0",
-		"gulp-minify-css": "~0.3.0",
+		"gulp-clean-css": "^2.3.2",
 		"gulp-rev": "~0.4.2",
 		"gulp-less": "2.0.1"
 	},

--- a/test/main.js
+++ b/test/main.js
@@ -230,7 +230,7 @@ describe('gulp-usemin', function() {
 
     describe('minified CSS:', function() {
       function compare(fixtureName, name, expectedName, end) {
-        var cssmin = require('gulp-minify-css');
+        var cssmin = require('gulp-clean-css');
         var stream = usemin({css: ['concat', cssmin()]});
 
         stream.on('data', function(newFile) {
@@ -362,7 +362,7 @@ describe('gulp-usemin', function() {
     });
 
     it('many html files', function(done) {
-      var cssmin = require('gulp-minify-css');
+      var cssmin = require('gulp-clean-css');
       var jsmin = require('gulp-uglify');
       var rev = require('gulp-rev');
       var stream = usemin({
@@ -405,7 +405,7 @@ describe('gulp-usemin', function() {
     });
 
     it('many blocks', function(done) {
-      var cssmin = require('gulp-minify-css');
+      var cssmin = require('gulp-clean-css');
       var jsmin = require('gulp-uglify');
       var rev = require('gulp-rev');
       var stream = usemin({
@@ -635,7 +635,7 @@ describe('gulp-usemin', function() {
 
     it('async task', function(done) {
       var less = require('gulp-less');
-      var cssmin = require('gulp-minify-css');
+      var cssmin = require('gulp-clean-css');
       var stream = usemin({
         less: [less(), 'concat', cssmin()]
       });


### PR DESCRIPTION
- Replace `gulp-minify-css` with `gulp-clean-css` as per suggestion on
npm https://www.npmjs.com/package/gulp-minify-css
- Add jshint package as gulp-jshint now requires it to be added manually
- Update package advanced range-syntax-versioning to be consistent
on all packages
- Version bump