### PR TITLE
Migrate gulp-util to individual modules (close #197)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 module.exports = function(options) {
   var through = require('through2');
-  var gutil = require('gulp-util');
+  var PluginError = require('plugin-error');
   var blocksBuilder = require('./lib/blocksBuilder.js');
   var htmlBuilder = require('./lib/htmlBuilder.js');
 
   return through.obj(function(file, enc, callback) {
     if (file.isStream()) {
-      this.emit('error', new gutil.PluginError('gulp-usemin', 'Streams are not supported!'));
+      this.emit('error', new PluginError('gulp-usemin', 'Streams are not supported!'));
       callback();
     }
     else if (file.isNull())

--- a/lib/blocksBuilder.js
+++ b/lib/blocksBuilder.js
@@ -1,7 +1,8 @@
 var fs = require('fs');
 var glob = require('glob');
 var path = require('path');
-var gutil = require('gulp-util');
+var PluginError = require('plugin-error');
+var Vinyl = require('vinyl');
 
 module.exports = function(file, options) {
   options = options || {};
@@ -53,7 +54,7 @@ module.exports = function(file, options) {
           cssMediaQuery = media;
         } else {
           if (cssMediaQuery != media)
-            throw new gutil.PluginError('gulp-usemin', 'incompatible css media query for ' + a + ' detected.');
+            throw new PluginError('gulp-usemin', 'incompatible css media query for ' + a + ' detected.');
         }
       });
     }
@@ -61,10 +62,10 @@ module.exports = function(file, options) {
     for (var i = 0, l = paths.length; i < l; ++i) {
       var filepaths = glob.sync(paths[i]);
       if(filepaths[0] === undefined && !options.skipMissingResources) {
-        throw new gutil.PluginError('gulp-usemin', 'Path ' + paths[i] + ' not found!');
+        throw new PluginError('gulp-usemin', 'Path ' + paths[i] + ' not found!');
       } else {
         filepaths.forEach(function (filepath) {
-          files.push(new gutil.File({
+          files.push(new Vinyl({
             path: filepath,
             contents: fs.readFileSync(filepath)
           }));

--- a/lib/htmlBuilder.js
+++ b/lib/htmlBuilder.js
@@ -1,6 +1,6 @@
 module.exports = function(file, blocks, options, push, callback) {
   var path = require('path');
-  var gutil = require('gulp-util');
+  var Vinyl = require('vinyl');
   var pipeline = require('./pipeline.js');
 
   var basePath = file.base;
@@ -9,7 +9,7 @@ module.exports = function(file, blocks, options, push, callback) {
 
   function createFile(name, content) {
     var filePath = path.join(path.relative(basePath, mainPath), name);
-    return new gutil.File({
+    return new Vinyl({
       path: filePath,
       contents: new Buffer(content)
     })

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
 	"description": "Replaces references to non-optimized scripts or stylesheets into a set of HTML files (or any templates/views).",
 	"main": "index.js",
 	"dependencies": {
-		"gulp-util": "~3.0.8",
-		"through2": "~2.0.3",
 		"glob": "~7.1.1",
-		"gulp-concat": "~2.6.1"
+		"gulp-concat": "~2.6.1",
+		"plugin-error": "~1.0.1",
+		"through2": "~2.0.3",
+		"vinyl": "~2.1.0"
 	},
 	"devDependencies": {
 		"event-stream": "~3.3.4",

--- a/test/main.js
+++ b/test/main.js
@@ -5,14 +5,14 @@
 
 var assert = require('assert');
 var fs = require('fs');
-var gutil = require('gulp-util');
 var PassThrough = require('stream').PassThrough;
 var path = require('path');
 var usemin = require('../index');
 var vfs = require('vinyl-fs');
+var Vinyl = require('vinyl');
 
 function getFile(filePath) {
-  return new gutil.File({
+  return new Vinyl({
     path:     filePath,
     base:     path.dirname(filePath),
     contents: fs.readFileSync(filePath)
@@ -66,7 +66,7 @@ describe('gulp-usemin', function() {
       var stream = usemin();
       var t;
       var fakeStream = new PassThrough();
-      var fakeFile = new gutil.File({
+      var fakeFile = new Vinyl({
         contents: fakeStream
       });
       fakeStream.end();
@@ -87,7 +87,7 @@ describe('gulp-usemin', function() {
     it('html without blocks', function(done) {
       var stream = usemin();
       var content = '<div>content</div>';
-      var fakeFile = new gutil.File({
+      var fakeFile = new Vinyl({
         path: 'test.file',
         contents: new Buffer(content)
       });
@@ -678,19 +678,18 @@ describe('gulp-usemin', function() {
   it('multiple files in stream', function(done) {
     var multipleFiles = function() {
       var through = require('through2');
-      var File = gutil.File;
 
       return through.obj(function(file) {
         var stream = this;
 
-        stream.push(new File({
+        stream.push(new Vinyl({
           cwd: file.cwd,
           base: file.base,
           path: file.path,
           contents: new Buffer('test1')
         }));
 
-        stream.push(new File({
+        stream.push(new Vinyl({
           cwd: file.cwd,
           base: file.base,
           path: file.path,


### PR DESCRIPTION
[`gulp-util`](https://www.npmjs.com/package/gulp-util) has been deprecated recently. See https://github.com/zont/gulp-usemin/issues/197.